### PR TITLE
fix: remove translation symlink

### DIFF
--- a/src/audio/translations
+++ b/src/audio/translations
@@ -1,1 +1,0 @@
-conf/locale


### PR DESCRIPTION
fixes `error: can't copy 'src/audio/translations': doesn't exist or not a regular file`
https://github.com/openedx/xblocks-extra/actions/runs/24033725373/job/70088123482