### PR TITLE
Remove symlink inside imagemodal

### DIFF
--- a/src/imagemodal/translations
+++ b/src/imagemodal/translations
@@ -1,1 +1,0 @@
-conf/locale


### PR DESCRIPTION
Fix following error occurring in the release pipeline

```error: can't copy 'src/imagemodal/translations': doesn't exist or not a regular file```

https://github.com/openedx/xblocks-extra/actions/runs/24341168474/job/71070291738
