### PR TITLE
Fix the Instructor Dashboard crash caused for feedback xblock

### DIFF
--- a/src/feedback/extensions/filters.py
+++ b/src/feedback/extensions/filters.py
@@ -11,7 +11,6 @@ from openedx_filters import PipelineStep
 from web_fragments.fragment import Fragment
 
 try:
-    # from cms.djangoapps.contentstore.utils import get_lms_link_for_item
     from lms.djangoapps.courseware.block_render import get_block_by_usage_id, load_single_xblock
     from openedx.core.djangoapps.enrollments.data import get_user_enrollments
     from xmodule.modulestore.django import modulestore

--- a/src/feedback/extensions/filters.py
+++ b/src/feedback/extensions/filters.py
@@ -11,10 +11,12 @@ from openedx_filters import PipelineStep
 from web_fragments.fragment import Fragment
 
 try:
-    from cms.djangoapps.contentstore.utils import get_lms_link_for_item
+    # from cms.djangoapps.contentstore.utils import get_lms_link_for_item
     from lms.djangoapps.courseware.block_render import get_block_by_usage_id, load_single_xblock
     from openedx.core.djangoapps.enrollments.data import get_user_enrollments
     from xmodule.modulestore.django import modulestore
+
+    from feedback.utils import get_lms_link_for_item
 except ImportError:
     load_single_xblock = None
     get_block_by_usage_id = None

--- a/src/feedback/feedbacktests/test_utils.py
+++ b/src/feedback/feedbacktests/test_utils.py
@@ -1,0 +1,64 @@
+import sys
+import types
+from unittest.mock import Mock
+
+from opaque_keys.edx.keys import UsageKey
+
+from feedback.utils import get_lms_link_for_item
+
+
+def test_get_lms_link_importerror(monkeypatch):
+    location = Mock(spec=UsageKey)
+    location.org = "edX"
+    location.course_key = "course-v1:edX+DemoX+2024"
+    location.__str__ = lambda self=location: "dummy"
+
+    if "openedx.core.djangoapps.site_configuration.models" in sys.modules:
+        del sys.modules["openedx.core.djangoapps.site_configuration.models"]
+
+    monkeypatch.setattr("feedback.utils.settings", types.SimpleNamespace(LMS_ROOT_URL="https://example.com"))
+
+    result = get_lms_link_for_item(location)
+    assert result is None
+
+
+def test_get_lms_link_with_null_lms_base(monkeypatch):
+    location = Mock(spec=UsageKey)
+    location.org = "edX"
+    location.course_key = "dummy"
+    location.__str__ = lambda self=location: "dummy"
+
+    class MockSiteConfiguration:
+        @staticmethod
+        def get_value_for_org(org, key, default):
+            return None  # simulate LMS base not set
+
+    monkeypatch.setitem(
+        sys.modules,
+        "openedx.core.djangoapps.site_configuration.models",
+        types.SimpleNamespace(SiteConfiguration=MockSiteConfiguration),
+    )
+
+    result = get_lms_link_for_item(location)
+    assert result is None
+
+
+def test_get_lms_link_with_preview(monkeypatch):
+    location = Mock(spec=UsageKey)
+    location.org = "edX"
+    location.course_key = "course-v1:edX+DemoX+2024"
+    location.__str__ = lambda self=location: "dummy"
+
+    class MockSiteConfiguration:
+        @staticmethod
+        def get_value_for_org(org, key, default):
+            return "https://fallback.com"
+
+    monkeypatch.setitem(
+        sys.modules,
+        "openedx.core.djangoapps.site_configuration.models",
+        types.SimpleNamespace(SiteConfiguration=MockSiteConfiguration),
+    )
+
+    result = get_lms_link_for_item(location, preview=True)
+    assert result == "https://fallback.com/courses/course-v1:edX+DemoX+2024/jump_to/dummy?preview=1"

--- a/src/feedback/feedbacktests/test_utils.py
+++ b/src/feedback/feedbacktests/test_utils.py
@@ -13,8 +13,11 @@ def test_get_lms_link_importerror(monkeypatch):
     location.course_key = "course-v1:edX+DemoX+2024"
     location.__str__ = lambda self=location: "dummy"
 
-    if "openedx.core.djangoapps.site_configuration.models" in sys.modules:
-        del sys.modules["openedx.core.djangoapps.site_configuration.models"]
+    monkeypatch.setitem(
+        sys.modules,
+        "openedx.core.djangoapps.site_configuration.models",
+        None,
+    )
 
     monkeypatch.setattr("feedback.utils.settings", types.SimpleNamespace(LMS_ROOT_URL="https://example.com"))
 

--- a/src/feedback/settings/test.py
+++ b/src/feedback/settings/test.py
@@ -23,3 +23,5 @@ FEATURES = {
 }
 
 SECRET_KEY = "fake-key"
+
+LMS_ROOT_URL = "https://example.com"

--- a/src/feedback/utils.py
+++ b/src/feedback/utils.py
@@ -1,6 +1,40 @@
 """Utilities for feedback app"""
 
+from urllib.parse import urlencode, urlparse, urlunparse
+
+from django.conf import settings
+from opaque_keys.edx.keys import UsageKey
+
 
 def _(text):
     """Dummy `gettext` replacement to make string extraction tools scrape strings marked for translation"""
     return text
+
+
+def get_lms_link_for_item(location, preview=False):
+    """
+    Returns an LMS link to the course with a jump_to to the provided location.
+    """
+    assert isinstance(location, UsageKey)
+
+    try:
+        # pylint: disable=import-outside-toplevel
+        from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
+
+    except ImportError:
+        return None
+
+    lms_base = SiteConfiguration.get_value_for_org(location.org, "LMS_ROOT_URL", settings.LMS_ROOT_URL)
+
+    if lms_base is None:
+        return None
+
+    query_string = ""
+    if preview:
+        query_string = urlencode({"preview": "1"})
+
+    url_parts = list(urlparse(lms_base))
+    url_parts[2] = f"/courses/{location.course_key}/jump_to/{location}"
+    url_parts[4] = query_string
+
+    return urlunparse(url_parts)

--- a/src/feedback/utils.py
+++ b/src/feedback/utils.py
@@ -1,5 +1,6 @@
 """Utilities for feedback app"""
 
+import sys
 from urllib.parse import urlencode, urlparse, urlunparse
 
 from django.conf import settings
@@ -17,12 +18,19 @@ def get_lms_link_for_item(location, preview=False):
     """
     assert isinstance(location, UsageKey)
 
+    # Hack: Import SiteConfiguration from openedx-platform.
+    # Please note that XBlocks should not import core openedx-platform code. Do not
+    # replicate this pattern elsewhere. If you need information from the platform, it's better
+    # to catch an event, hook into a filter, or define and use an XBlock runtime service.
     try:
         # pylint: disable=import-outside-toplevel
         from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
-
     except ImportError:
-        return None
+        if "unittest" in sys.modules.keys():
+            # Fail silently when testing. We can't install openedx-platform for tests.
+            return None
+        # Otherwise, fail loudly, so that we will notice if the openedx-platform import path changes.
+        raise
 
     lms_base = SiteConfiguration.get_value_for_org(location.org, "LMS_ROOT_URL", settings.LMS_ROOT_URL)
 


### PR DESCRIPTION
## Description

Fixes the Instructor Dashboard crash caused by an indirect import chain that pulls in `openedx.core.djangoapps.content.search` — an app not registered in `INSTALLED_APPS` on the LMS.

Resolves: https://github.com/openedx/FeedbackXBlock/issues/164

### Root Cause

When the `AddFeedbackTab` filter pipeline renders the Feedback tab on the Instructor Dashboard, `filters.py` imports `get_lms_link_for_item` directly from `cms.djangoapps.contentstore.utils`. This triggers the following import chain at module load time:

```
cms.djangoapps.contentstore.utils
  → cms/djangoapps/contentstore/toggles.py
    → openedx.core.djangoapps.content.search.api
      → SearchAccess (model)
```

The `content.search` app was introduced in 2024 and is only available in the CMS (Studio) context. Because it is not included in `INSTALLED_APPS` on the LMS, the import fails at runtime, breaking the entire Instructor Dashboard Feedback tab for Open edX platforms running Sumac or later.

For more details Ref: https://github.com/openedx/FeedbackXBlock/issues/164

### Fix

This PR replicates the fix from [openedx/FeedbackXBlock#166](https://github.com/openedx/FeedbackXBlock/pull/166): the direct import of `get_lms_link_for_item` from `cms.djangoapps.contentstore.utils` is replaced with a locally re-implemented version in `feedback/utils.py`. The new implementation uses `SiteConfiguration.get_value_for_org` (guarded by a `try/except ImportError`) to resolve the LMS base URL, decoupling the XBlock from CMS-only platform internals.

This makes the XBlock self-contained and compatible with both LMS and Studio environments.

### How to Test

1. Install the XBlock from this branch.
2. To enable the FeedbackXBlock report in the instructor dashboard, you can use the tutor inline plugins: https://github.com/openedx/FeedbackXBlock?tab=readme-ov-file#tutor-configuration

3. Navigate to the Instructor Dashboard of a course using the Feedback XBlock.
4. Click the **Feedback** tab — it should render without errors.

### Testing Results After Fix:
<img width="1491" height="752" alt="Screenshot 2026-04-14 at 12 41 24 PM" src="https://github.com/user-attachments/assets/b9f5045f-24ae-419f-bed9-a172d24aa9f7" />
