### PR TITLE
fix: use built-in GITHUB_TOKEN for semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         id: release
         uses: python-semantic-release/python-semantic-release@v10
         with:
-          github_token: ${{ secrets.OPENEDX_SEMANTIC_RELEASE_GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           git_committer_name: "github-actions"
           git_committer_email: "actions@users.noreply.github.com"
           changelog: "false"
@@ -45,7 +45,7 @@ jobs:
         uses: python-semantic-release/publish-action@v10
         if: steps.release.outputs.released == 'true'
         with:
-          github_token: ${{ secrets.OPENEDX_SEMANTIC_RELEASE_GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.release.outputs.tag }}
 
       - name: Upload distribution artifacts


### PR DESCRIPTION
The org-level OPENEDX_SEMANTIC_RELEASE_GITHUB_TOKEN PAT did not have
write access to this repo, causing a 404 when trying to create GitHub
releases. The built-in GITHUB_TOKEN is automatically scoped to the
current repo and the job already has `permissions: contents: write`.

Once this lands, we don't need to actually have the semantic-release-bot user have write access to this repository.
