### PR TITLE
feat: add Transifex config for freetextresponse translations

### DIFF
--- a/src/freetextresponse/.tx/config
+++ b/src/freetextresponse/.tx/config
@@ -1,0 +1,8 @@
+[main]
+host = https://www.transifex.com
+
+[o:open-edx:p:openedx-translations:r:xblocks-extra-freetextresponse]
+file_filter = conf/locale/<lang>/LC_MESSAGES/text.po
+source_file = conf/locale/en/LC_MESSAGES/text.po
+source_lang = en
+type        = PO


### PR DESCRIPTION
## Summary

- Adds `src/freetextresponse/.tx/config` to wire `freetextresponse` into the openedx-translations pipeline
- The resource slug is `xblocks-extra-freetextresponse`, matching the pattern used by all other xblocks in this repo (e.g. `xblocks-extra-sql-grader`, `xblocks-extra-submit-and-compare`)
- No other changes needed: `conf/locale/config.yaml` already exists, and the Makefile auto-discovers `freetextresponse` via `find src/ -mindepth 2 -maxdepth 2 -type d -name 'conf'`

Closes #41 (together with a companion PR in openedx/openedx-translations adding the `transifex.yml` entry)

## Merge sequence

1. **Merge this PR (#45)** — triggers extraction run, populates `translations/xblocks-extra/freetextresponse/` in openedx-translations
2. Merge openedx/openedx-translations#74373 — adds `transifex.yml` entry for `xblocks-extra/freetextresponse`
3. Verify openedx/xblocks-extra#42 — confirm new path has ≥ 37 locales (matches legacy `xblock-free-text-response` coverage)
4. Merge openedx/openedx-translations#74375 — removes legacy `xblock-free-text-response` entries (resolves #43)
5. openedx/xblocks-extra#44 — manual LMS validation: run `make pull_xblock_translations` in `lms-shell` and confirm translated UI renders correctly

## Test plan

- [ ] CI passes (lint + tests)
- [ ] Companion PR openedx/openedx-translations#74373 is open and `extract-translation-source-files` workflow validates the entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)