### PR TITLE
chore: remove manual version/changelog checklist items from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,6 @@
 
 **Merge checklist:**
 Check off if complete *or* not applicable:
-- [ ] Version bumped
-- [ ] Changelog record added
 - [ ] Documentation updated (not only docstrings)
 - [ ] Fixup commits are squashed away
 - [ ] Unit tests added/updated


### PR DESCRIPTION
## Summary

- Removes `Version bumped` and `Changelog record added` checklist items from the PR template
- Both are now automated via semantic-release, so manual contributor action is no longer needed and keeping them would be misleading

## Test plan

- [ ] Verify the PR template no longer shows these items when opening a new PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)